### PR TITLE
Batched build request

### DIFF
--- a/beacon/engine/gen_blockparams.go
+++ b/beacon/engine/gen_blockparams.go
@@ -22,6 +22,7 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 		Withdrawals           []*types.Withdrawal `json:"withdrawals"`
 		BeaconRoot            *common.Hash        `json:"parentBeaconBlockRoot"`
 		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
+		NextInfoTxs           []hexutil.Bytes     `json:"nextInfoTxs,omitempty"  gencodec:"optional"`
 		NoTxPool              bool                `json:"noTxPool,omitempty" gencodec:"optional"`
 		GasLimit              *hexutil.Uint64     `json:"gasLimit,omitempty" gencodec:"optional"`
 		EIP1559Params         hexutil.Bytes       `json:"eip1559Params,omitempty" gencodec:"optional"`
@@ -36,6 +37,12 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 		enc.Transactions = make([]hexutil.Bytes, len(p.Transactions))
 		for k, v := range p.Transactions {
 			enc.Transactions[k] = v
+		}
+	}
+	if p.NextInfoTxs != nil {
+		enc.NextInfoTxs = make([]hexutil.Bytes, len(p.NextInfoTxs))
+		for k, v := range p.NextInfoTxs {
+			enc.NextInfoTxs[k] = v
 		}
 	}
 	enc.NoTxPool = p.NoTxPool
@@ -53,6 +60,7 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 		Withdrawals           []*types.Withdrawal `json:"withdrawals"`
 		BeaconRoot            *common.Hash        `json:"parentBeaconBlockRoot"`
 		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
+		NextInfoTxs           []hexutil.Bytes     `json:"nextInfoTxs,omitempty"  gencodec:"optional"`
 		NoTxPool              *bool               `json:"noTxPool,omitempty" gencodec:"optional"`
 		GasLimit              *hexutil.Uint64     `json:"gasLimit,omitempty" gencodec:"optional"`
 		EIP1559Params         *hexutil.Bytes      `json:"eip1559Params,omitempty" gencodec:"optional"`
@@ -83,6 +91,12 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 		p.Transactions = make([][]byte, len(dec.Transactions))
 		for k, v := range dec.Transactions {
 			p.Transactions[k] = v
+		}
+	}
+	if dec.NextInfoTxs != nil {
+		p.NextInfoTxs = make([][]byte, len(dec.NextInfoTxs))
+		for k, v := range dec.NextInfoTxs {
+			p.NextInfoTxs[k] = v
 		}
 	}
 	if dec.NoTxPool != nil {

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -51,6 +51,8 @@ type PayloadAttributes struct {
 
 	// Transactions is a field for rollups: the transactions list is forced into the block
 	Transactions [][]byte `json:"transactions,omitempty"  gencodec:"optional"`
+	NextInfoTxs  [][]byte `json:"nextInfoTxs,omitempty"  gencodec:"optional"`
+
 	// NoTxPool is a field for rollups: if true, the no transactions are taken out of the tx-pool,
 	// only transactions from the above Transactions list will be included.
 	NoTxPool bool `json:"noTxPool,omitempty" gencodec:"optional"`
@@ -67,6 +69,7 @@ type payloadAttributesMarshaling struct {
 	Timestamp hexutil.Uint64
 
 	Transactions  []hexutil.Bytes
+	NextInfoTxs   []hexutil.Bytes
 	GasLimit      *hexutil.Uint64
 	EIP1559Params hexutil.Bytes
 }

--- a/core/evm.go
+++ b/core/evm.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
 )
@@ -37,6 +38,13 @@ type ChainContext interface {
 
 	// GetHeader returns the header corresponding to the hash/number argument pair.
 	GetHeader(common.Hash, uint64) *types.Header
+}
+
+func NewEVMBlockContextWithExtraHeaders(header *types.Header, chain ChainContext, author *common.Address, config *params.ChainConfig, statedb types.StateGetter, extras map[common.Hash]*types.Header) vm.BlockContext {
+	log.Info("createing context with extras", "len", len(extras))
+	blockContext := NewEVMBlockContext(header, chain, author, config, statedb)
+	blockContext.GetHash = GetHashFnWithExtraHeaders(header, chain, extras)
+	return blockContext
 }
 
 // NewEVMBlockContext creates a new context for use in the EVM.
@@ -90,6 +98,50 @@ func NewEVMTxContext(msg *Message) vm.TxContext {
 		ctx.BlobFeeCap = new(big.Int).Set(msg.BlobGasFeeCap)
 	}
 	return ctx
+}
+
+// GetHashFnWithExtraHeaders returns a GetHashFunc which retrieves header hashes by number from db and extras map
+func GetHashFnWithExtraHeaders(ref *types.Header, chain ChainContext, extras map[common.Hash]*types.Header) func(n uint64) common.Hash {
+	// Cache will initially contain [refHash.parent],
+	// Then fill up with [refHash.p, refHash.pp, refHash.ppp, ...]
+	var cache []common.Hash
+
+	return func(n uint64) common.Hash {
+		if ref.Number.Uint64() <= n {
+			// This situation can happen if we're doing tracing and using
+			// block overrides.
+			return common.Hash{}
+		}
+		// If there's no hash cache yet, make one
+		if len(cache) == 0 {
+			cache = append(cache, ref.ParentHash)
+		}
+		if idx := ref.Number.Uint64() - n - 1; idx < uint64(len(cache)) {
+			return cache[idx]
+		}
+		// No luck in the cache, but we can start iterating from the last element we already know
+		lastKnownHash := cache[len(cache)-1]
+		lastKnownNumber := ref.Number.Uint64() - uint64(len(cache))
+
+		for {
+			header := chain.GetHeader(lastKnownHash, lastKnownNumber)
+			if header == nil {
+				// check in the extras map
+				header = extras[lastKnownHash]
+				// return if it is not found
+				if header == nil {
+					break
+				}
+			}
+			cache = append(cache, header.ParentHash)
+			lastKnownHash = header.ParentHash
+			lastKnownNumber = header.Number.Uint64() - 1
+			if n == lastKnownNumber {
+				return lastKnownHash
+			}
+		}
+		return common.Hash{}
+	}
 }
 
 // GetHashFn returns a GetHashFunc which retrieves header hashes by number

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -210,14 +210,14 @@ func MakeReceipt(evm *vm.EVM, result *ExecutionResult, statedb *state.StateDB, b
 // for the transaction, gas used and an error if the transaction failed,
 // indicating the block was invalid.
 func ApplyTransaction(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config) (*types.Receipt, error) {
-	return ApplyTransactionExtended(config, bc, author, gp, statedb, header, tx, usedGas, cfg, nil)
+	return ApplyTransactionExtended(config, bc, author, gp, statedb, header, tx, usedGas, cfg, nil, nil)
 }
 
 type ApplyTransactionOpts struct {
 	PostValidation func(evm *vm.EVM, result *ExecutionResult) error
 }
 
-func ApplyTransactionExtended(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config, extraOpts *ApplyTransactionOpts) (*types.Receipt, error) {
+func ApplyTransactionExtended(config *params.ChainConfig, bc ChainContext, author *common.Address, gp *GasPool, statedb *state.StateDB, header *types.Header, tx *types.Transaction, usedGas *uint64, cfg vm.Config, extraOpts *ApplyTransactionOpts, extras map[common.Hash]*types.Header) (*types.Receipt, error) {
 	msg, err := TransactionToMessage(tx, types.MakeSigner(config, header.Number, header.Time), header.BaseFee)
 	if err != nil {
 		return nil, err
@@ -225,8 +225,13 @@ func ApplyTransactionExtended(config *params.ChainConfig, bc ChainContext, autho
 	if extraOpts != nil {
 		msg.PostValidation = extraOpts.PostValidation
 	}
-	// Create a new context to be used in the EVM environment
-	blockContext := NewEVMBlockContext(header, bc, author, config, statedb)
+	var blockContext vm.BlockContext
+	if extras == nil {
+		// Create a new context to be used in the EVM environment
+		blockContext = NewEVMBlockContext(header, bc, author, config, statedb)
+	} else {
+		blockContext = NewEVMBlockContextWithExtraHeaders(header, bc, author, config, statedb, extras)
+	}
 	txContext := NewEVMTxContext(msg)
 	vmenv := vm.NewEVM(blockContext, txContext, statedb, config, cfg)
 	return ApplyTransactionWithEVM(msg, config, gp, statedb, header.Number, header.Hash(), tx, usedGas, vmenv)

--- a/core/stateless/witness.go
+++ b/core/stateless/witness.go
@@ -68,6 +68,23 @@ func NewWitness(context *types.Header, chain HeaderReader) (*Witness, error) {
 	}, nil
 }
 
+// NewWitnessWithParent creates an empty witness set with the provided parent
+func NewWitnessWithParent(context, parent *types.Header, chain HeaderReader) (*Witness, error) {
+	if parent == nil {
+		return nil, errors.New("parent header is not available")
+	}
+	// Setting the parent header to acts as a trustless pre-root hash container
+	headers := []*types.Header{parent}
+
+	return &Witness{
+		context: context,
+		Headers: headers,
+		Codes:   make(map[string]struct{}),
+		State:   make(map[string]struct{}),
+		chain:   chain,
+	}, nil
+}
+
 // AddBlockHash adds a "blockhash" to the witness with the designated offset from
 // chain head. Under the hood, this method actually pulls in enough headers from
 // the chain to cover the block being added.

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -475,20 +475,61 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 			EIP1559Params: eip1559Params,
 		}
 		id := args.Id()
+		nextBuildArgs, err := buildNextPayloadArgs(args, payloadAttributes.NextInfoTxs)
+		if err != nil {
+			return engine.STATUS_INVALID, fmt.Errorf("failed to build args using nextInfoTxs %v", err)
+		}
+
 		// If we already are busy generating this work, then we do not need
 		// to start a second process.
+		// note that we cannot do this for the next build args because
+		// the parents are not known yet
 		if api.localBlocks.has(id) {
+			log.Warn("ID already exists. Returning", "id", id)
 			return valid(&id), nil
 		}
-		payload, err := api.eth.Miner().BuildPayload(args, payloadWitness)
+
+		allPayloadArgs := append([]*miner.BuildPayloadArgs{args}, nextBuildArgs...)
+		payload, err := api.eth.Miner().BuildBatchedPayloads(allPayloadArgs, payloadWitness, api.localBlocks.put)
 		if err != nil {
 			log.Error("Failed to build payload", "err", err)
 			return valid(nil), engine.InvalidPayloadAttributes.With(err)
 		}
-		api.localBlocks.put(id, payload)
+		api.localBlocks.CheckAndPut(id, payload)
 		return valid(&id), nil
 	}
 	return valid(nil), nil
+}
+
+// buildNextPayloadArgs builds next payloads using the base payload. This only works for txs within the same epoch
+func buildNextPayloadArgs(base *miner.BuildPayloadArgs, nextInfoTxs [][]byte) ([]*miner.BuildPayloadArgs, error) {
+	var (
+		argsSet []*miner.BuildPayloadArgs
+	)
+
+	for i, iTx := range nextInfoTxs {
+		var tx types.Transaction
+		if err := tx.UnmarshalBinary(iTx); err != nil {
+			return []*miner.BuildPayloadArgs{}, fmt.Errorf("next info transaction %d is not valid: %v", i, err)
+		}
+		// TODO: update this with block time from a config
+		nextTime := base.Timestamp + uint64((i+1)*2)
+		args := &miner.BuildPayloadArgs{
+			//parent will be set later on
+			Timestamp:    nextTime,
+			FeeRecipient: base.FeeRecipient,
+			Random:       base.Random,
+			BeaconRoot:   base.BeaconRoot,
+			NoTxPool:     base.NoTxPool,
+			Transactions: []*types.Transaction{&tx},
+			GasLimit:     base.GasLimit,
+			Version:      base.Version,
+			Withdrawals:  []*types.Withdrawal{},
+		}
+
+		argsSet = append(argsSet, args)
+	}
+	return argsSet, nil
 }
 
 // ExchangeTransitionConfigurationV1 checks the given configuration against

--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -73,6 +73,24 @@ func (q *payloadQueue) put(id engine.PayloadID, payload *miner.Payload) {
 	}
 }
 
+// CheckAndPut only inserts if the value doesn't exist
+func (q *payloadQueue) CheckAndPut(id engine.PayloadID, payload *miner.Payload) {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+	// if the value exists do nothing
+	for _, item := range q.payloads {
+		if item.id == id {
+			return
+		}
+	}
+	// insert otherwise
+	copy(q.payloads[1:], q.payloads)
+	q.payloads[0] = &payloadQueueItem{
+		id:      id,
+		payload: payload,
+	}
+}
+
 // get retrieves a previously stored payload item or nil if it does not exist.
 func (q *payloadQueue) get(id engine.PayloadID, full bool) *engine.ExecutionPayloadEnvelope {
 	q.lock.RLock()

--- a/eth/catalyst/queue.go
+++ b/eth/catalyst/queue.go
@@ -79,7 +79,7 @@ func (q *payloadQueue) CheckAndPut(id engine.PayloadID, payload *miner.Payload) 
 	defer q.lock.RUnlock()
 	// if the value exists do nothing
 	for _, item := range q.payloads {
-		if item.id == id {
+		if item != nil && item.id == id {
 			return
 		}
 	}

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -214,6 +214,7 @@ func (miner *Miner) BuildBatchedPayloads(args []*BuildPayloadArgs, witness bool,
 				firstResultRetCh <- &PayloadBuildResult{Payload: pl, Err: err}
 			}
 			if err != nil {
+				log.Error("encountered error in optimistic batch building", "i", i, "err", err)
 				return
 			}
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -19,11 +19,13 @@ package miner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -33,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/types/interoptypes"
 	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -180,6 +183,81 @@ func (miner *Miner) SetMaxDASize(maxTxSize, maxBlockSize *big.Int) {
 		miner.config.MaxDABlockSize = new(big.Int).Set(maxBlockSize)
 	}
 	miner.confMu.Unlock()
+}
+
+type PayloadBuildResult struct {
+	*Payload
+	Err error
+}
+
+// BuildBatchedPayloads batch builds the payloads without waiting for the next FCU signal
+// TODO: Cancel batched payload building if a new epoch starts prematurely, or if the FCU
+// requests a payload with an ID different from those provided here
+func (miner *Miner) BuildBatchedPayloads(args []*BuildPayloadArgs, witness bool, checkAndPutPayload func(engine.PayloadID, *Payload)) (*Payload, error) {
+
+	var (
+		nextEnvParams *EnvParams
+		resultCh      = make(chan *PayloadBuildResult)
+	)
+
+	// build payloads in the background
+	go func(firstResultRetCh chan *PayloadBuildResult) {
+		defer close(resultCh)
+		for i, a := range args {
+			//update the args
+			if nextEnvParams != nil {
+				a.Parent = nextEnvParams.Parent.Hash() // set the parent
+				a.eParams = nextEnvParams
+			}
+			pl, err := miner.buildPayload(a, witness)
+			if i == 0 {
+				firstResultRetCh <- &PayloadBuildResult{Payload: pl, Err: err}
+			}
+			if err != nil {
+				return
+			}
+
+			// insert the rest of the payloads
+			if i > 0 {
+				// simply insert the payload
+				log.Info("Inserted concurrent payload")
+				// it's safe to concurrently insert payloads
+				checkAndPutPayload(pl.id, pl)
+			}
+
+			// wait for the payload to stop
+			if _, ok := <-pl.stop; !ok {
+				log.Debug("payload stopped, creating next in batch building")
+			}
+			// if state is not available then we cannot build the next block
+			if pl.State == nil {
+				log.Debug("state not available. Breaking optimistic exec")
+				break
+			}
+
+			// populate env for the next build
+			if pl.full != nil {
+				nextEnvParams = &EnvParams{
+					Parent: pl.full.Header(),
+					State:  pl.State,
+				}
+			} else if pl.empty != nil {
+				nextEnvParams = &EnvParams{
+					Parent: pl.empty.Header(),
+					State:  pl.State,
+				}
+			} else {
+				log.Error("no blocks available in the payload")
+			}
+		}
+	}(resultCh)
+
+	result, ok := <-resultCh
+	if !ok {
+		return nil, errors.New("failed to build payload")
+	}
+
+	return result.Payload, result.Err
 }
 
 // BuildPayload builds the payload according to the provided parameters.

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -29,12 +29,19 @@ import (
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 )
+
+// EnvParams are the parameters for building the environment for the execution
+type EnvParams struct {
+	Parent *types.Header
+	State  *state.StateDB // state after the execution of parent block
+}
 
 // BuildPayloadArgs contains the provided parameters for building payload.
 // Check engine-api specification for more details.
@@ -52,6 +59,32 @@ type BuildPayloadArgs struct {
 	Transactions  []*types.Transaction // Optimism addition: txs forced into the block via engine API
 	GasLimit      *uint64              // Optimism addition: override gas limit of the block to build
 	EIP1559Params []byte               // Optimism addition: encodes Holocene EIP-1559 params
+
+	eParams *EnvParams //parameters for setting up execution environment
+}
+
+func (args *BuildPayloadArgs) PrintArgs() {
+	log.Info("\n****************")
+	log.Info("data", "Parent", args.Parent.Hex(), "feeRecip", args.FeeRecipient.Hex(), "withdrawals", args.Withdrawals)
+	log.Info("data", "timestamp", args.Timestamp, "random", args.Random.Hex())
+	if args.BeaconRoot != nil {
+		log.Info("data", "beacon root", args.BeaconRoot)
+	}
+	if args.NoTxPool || len(args.Transactions) > 0 { // extend if extra payload attributes are used
+		log.Info("data", "no txpool", args.NoTxPool)
+		log.Info("txs", "len txs", uint64(len(args.Transactions)))
+		for _, tx := range args.Transactions {
+			log.Info("tx hash", "tx hash", tx.Hash())
+		}
+	}
+	if args.GasLimit != nil {
+		log.Info("gas", "gas limit", *args.GasLimit)
+	}
+	if len(args.EIP1559Params) != 0 {
+		log.Info("args", "eip", args.EIP1559Params[:])
+	}
+	log.Info("****************\n")
+
 }
 
 // Id computes an 8-byte identifier by hashing the components of the payload arguments.
@@ -103,6 +136,7 @@ type Payload struct {
 	stop         chan struct{}
 	lock         sync.Mutex
 	cond         *sync.Cond
+	State        *state.StateDB // keeping state if subsequent payload wants to use it
 
 	err       error
 	stopOnce  sync.Once
@@ -129,6 +163,13 @@ func newPayload(lifeCtx context.Context, empty *types.Block, witness *stateless.
 	log.Info("Starting work on payload", "id", payload.id)
 	payload.cond = sync.NewCond(&payload.lock)
 	return payload
+}
+
+// withState sets state to the payload
+func (payload *Payload) withState(state *state.StateDB) {
+	payload.lock.Lock()
+	defer payload.lock.Unlock()
+	payload.State = state
 }
 
 var errInterruptedUpdate = errors.New("interrupted payload update")
@@ -164,6 +205,7 @@ func (payload *Payload) update(r *newPayloadResult, elapsed time.Duration) {
 		payload.fullFees = r.fees
 		payload.sidecars = r.sidecars
 		payload.fullWitness = r.witness
+		payload.State = r.stateDB.Copy()
 
 		feesInEther := new(big.Float).Quo(new(big.Float).SetInt(r.fees), big.NewFloat(params.Ether))
 		log.Info("Updated payload",
@@ -306,13 +348,15 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 			gasLimit:      args.GasLimit,
 			eip1559Params: args.EIP1559Params,
 			// No RPC requests allowed.
-			rpcCtx: nil,
+			rpcCtx:   nil,
+			envParam: args.eParams,
 		}
 		empty := miner.generateWork(emptyParams, witness)
 		if empty.err != nil {
 			return nil, empty.err
 		}
 		payload := newPayload(miner.lifeCtx, empty.block, empty.witness, args.Id())
+		payload.withState(empty.stateDB.Copy()) // set a copy of the state
 		// make sure to make it appear as full, otherwise it will wait indefinitely for payload building to complete.
 		payload.full = empty.block
 		payload.fullFees = empty.fees
@@ -332,6 +376,7 @@ func (miner *Miner) buildPayload(args *BuildPayloadArgs, witness bool) (*Payload
 		txs:           args.Transactions,
 		gasLimit:      args.GasLimit,
 		eip1559Params: args.EIP1559Params,
+		envParam:      args.eParams, // params to create execution environment
 	}
 
 	// Since we skip building the empty block when using the tx pool, we need to explicitly

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -79,8 +79,9 @@ type environment struct {
 
 	witness *stateless.Witness
 
-	noTxs  bool            // true if we are reproducing a block, and do not have to check interop txs
-	rpcCtx context.Context // context to control block-building RPC work. No RPC allowed if nil.
+	noTxs        bool                          // true if we are reproducing a block, and do not have to check interop txs
+	rpcCtx       context.Context               // context to control block-building RPC work. No RPC allowed if nil.
+	extraHeaders map[common.Hash]*types.Header //set of block headers that may not be part of chain yet
 }
 
 const (
@@ -341,6 +342,14 @@ func (miner *Miner) makeEnvWithState(eParams *EnvParams, parent *types.Header, h
 	if eParams.Parent == nil || eParams.Parent.Hash() != parent.Hash() {
 		return nil, errors.New("parent in params doesn't match with the env parent")
 	}
+	// check if the grandparent header exists in the chain
+	gParent := miner.chain.GetBlockByHash(parent.ParentHash)
+	if gParent == nil {
+		// grandparent doesn't exists. It means that the optimistic payload building is far ahead of
+		// the tip of the chain. Optimistic batch building should stop at this point.
+		// It is not supported atm. Only parent can be missing from the chain
+		return nil, errors.New("missing grandparent")
+	}
 
 	state := eParams.State
 	if witness {
@@ -350,14 +359,18 @@ func (miner *Miner) makeEnvWithState(eParams *EnvParams, parent *types.Header, h
 		}
 		state.StartPrefetcher("miner", bundle)
 	}
+	absentHeaders := make(map[common.Hash]*types.Header)
+	absentHeaders[parent.Hash()] = parent
+
 	// Note the passed coinbase may be different with header.Coinbase.
 	return &environment{
-		signer:   types.MakeSigner(miner.chainConfig, header.Number, header.Time),
-		state:    state,
-		coinbase: coinbase,
-		header:   header,
-		witness:  state.Witness(),
-		rpcCtx:   rpcCtx,
+		signer:       types.MakeSigner(miner.chainConfig, header.Number, header.Time),
+		state:        state,
+		coinbase:     coinbase,
+		header:       header,
+		witness:      state.Witness(),
+		rpcCtx:       rpcCtx,
+		extraHeaders: absentHeaders,
 	}, nil
 
 }
@@ -483,7 +496,7 @@ func (miner *Miner) applyTransaction(env *environment, tx *types.Transaction) (*
 			},
 		}
 	}
-	receipt, err := core.ApplyTransactionExtended(miner.chainConfig, miner.chain, &env.coinbase, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, vm.Config{}, extraOpts)
+	receipt, err := core.ApplyTransactionExtended(miner.chainConfig, miner.chain, &env.coinbase, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, vm.Config{}, extraOpts, env.extraHeaders)
 	if err != nil {
 		env.state.RevertToSnapshot(snap)
 		env.gasPool.SetGas(gp)
@@ -759,6 +772,13 @@ func (miner *Miner) validateParams(genParams *generateParams) (time.Duration, er
 
 	var parent *types.Header
 	if genParams.envParam != nil && genParams.envParam.Parent != nil {
+		gParent := miner.chain.GetBlockByHash(genParams.envParam.Parent.ParentHash)
+		if gParent == nil {
+			// grandparent doesn't exists. It means that the optimistic payload building is far ahead of
+			// the tip of the chain. Optimistic batch building should stop at this point.
+			// It is not supported atm. Only parent can be missing from the chain
+			return 0, errors.New("missing grandparent")
+		}
 		parent = genParams.envParam.Parent
 	} else {
 		// Find the parent block for sealing task

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -120,6 +120,8 @@ type generateParams struct {
 	isUpdate      bool               // Optional flag indicating that this is building a discardable update
 
 	rpcCtx context.Context // context to control block-building RPC work. No RPC allowed if nil.
+
+	envParam *EnvParams // params for creating the environment
 }
 
 // generateWork generates a sealing block based on the given parameters.
@@ -209,14 +211,19 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 	miner.confMu.RLock()
 	defer miner.confMu.RUnlock()
 
-	// Find the parent block for sealing task
-	parent := miner.chain.CurrentBlock()
-	if genParams.parentHash != (common.Hash{}) {
-		block := miner.chain.GetBlockByHash(genParams.parentHash)
-		if block == nil {
-			return nil, errors.New("missing parent")
+	var parent *types.Header
+	if genParams.envParam != nil && genParams.envParam.Parent != nil {
+		parent = genParams.envParam.Parent
+	} else {
+		// Find the parent block for sealing task
+		parent = miner.chain.CurrentBlock()
+		if genParams.parentHash != (common.Hash{}) {
+			block := miner.chain.GetBlockByHash(genParams.parentHash)
+			if block == nil {
+				return nil, errors.New("missing parent")
+			}
+			parent = block.Header()
 		}
-		parent = block.Header()
 	}
 	// Sanity check the timestamp correctness, recap the timestamp
 	// to parent+1 if the mutation is allowed.
@@ -292,13 +299,25 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 		header.ExcessBlobGas = &excessBlobGas
 		header.ParentBeaconRoot = genParams.beaconRoot
 	}
+	var (
+		env *environment
+		err error
+	)
 	// Could potentially happen if starting to mine in an odd state.
 	// Note genParams.coinbase can be different with header.Coinbase
 	// since clique algorithm can modify the coinbase field in header.
-	env, err := miner.makeEnv(parent, header, genParams.coinbase, witness, genParams.rpcCtx)
-	if err != nil {
-		log.Error("Failed to create sealing context", "err", err)
-		return nil, err
+	if genParams.envParam != nil && genParams.envParam.State != nil {
+		env, err = miner.makeEnvWithState(genParams.envParam, parent, header, genParams.coinbase, witness, genParams.rpcCtx)
+		if err != nil {
+			log.Error("Failed to create sealing context from given state", "err", err)
+			return nil, err
+		}
+	} else {
+		env, err = miner.makeEnv(parent, header, genParams.coinbase, witness, genParams.rpcCtx)
+		if err != nil {
+			log.Error("Failed to create sealing context", "err", err)
+			return nil, err
+		}
 	}
 	env.noTxs = genParams.noTxs
 	if header.ParentBeaconRoot != nil {
@@ -312,6 +331,35 @@ func (miner *Miner) prepareWork(genParams *generateParams, witness bool) (*envir
 		core.ProcessParentBlockHash(header.ParentHash, vmenv, env.state)
 	}
 	return env, nil
+}
+
+// makeEnvWithState builds execution environmnet with the already built base state
+func (miner *Miner) makeEnvWithState(eParams *EnvParams, parent *types.Header, header *types.Header, coinbase common.Address, witness bool, rpcCtx context.Context) (*environment, error) {
+	if eParams == nil || eParams.State == nil {
+		return nil, errors.New("base state doesn't exist in env")
+	}
+	if eParams.Parent == nil || eParams.Parent.Hash() != parent.Hash() {
+		return nil, errors.New("parent in params doesn't match with the env parent")
+	}
+
+	state := eParams.State
+	if witness {
+		bundle, err := stateless.NewWitnessWithParent(header, parent, miner.chain)
+		if err != nil {
+			return nil, err
+		}
+		state.StartPrefetcher("miner", bundle)
+	}
+	// Note the passed coinbase may be different with header.Coinbase.
+	return &environment{
+		signer:   types.MakeSigner(miner.chainConfig, header.Number, header.Time),
+		state:    state,
+		coinbase: coinbase,
+		header:   header,
+		witness:  state.Witness(),
+		rpcCtx:   rpcCtx,
+	}, nil
+
 }
 
 // makeEnv creates a new environment for the sealing block.
@@ -709,14 +757,19 @@ func (miner *Miner) validateParams(genParams *generateParams) (time.Duration, er
 	miner.confMu.RLock()
 	defer miner.confMu.RUnlock()
 
-	// Find the parent block for sealing task
-	parent := miner.chain.CurrentBlock()
-	if genParams.parentHash != (common.Hash{}) {
-		block := miner.chain.GetBlockByHash(genParams.parentHash)
-		if block == nil {
-			return 0, fmt.Errorf("missing parent %v", genParams.parentHash)
+	var parent *types.Header
+	if genParams.envParam != nil && genParams.envParam.Parent != nil {
+		parent = genParams.envParam.Parent
+	} else {
+		// Find the parent block for sealing task
+		parent = miner.chain.CurrentBlock()
+		if genParams.parentHash != (common.Hash{}) {
+			block := miner.chain.GetBlockByHash(genParams.parentHash)
+			if block == nil {
+				return 0, fmt.Errorf("missing parent %v", genParams.parentHash)
+			}
+			parent = block.Header()
 		}
-		parent = block.Header()
 	}
 
 	// Sanity check the timestamp correctness


### PR DESCRIPTION
This PR introduces optimistic payload building.

Currently, a new payload build is requested in a `forkChoiceUpdated` call containing non-nil payloadAttributes. This spawns a background process that begins building the payload. The process executes transactions according to the configuration and generates the state.

Afterwards, `GetPayload()` is called by the sequencer, which stops the payload building and returns the executableData. This contains all the necessary data to form a block.

Next, `NewPayload()` is called to convert the executableData into a block, re-execute the block's transactions for validation, and prepare it for insertion into the chain. At this point, the blockchain head is not updated yet.

Finally, `forkChoiceUpdated` is called again to set the block as canonical and move the head.  It looks like this:

  FCU -> GetPaylod -> NewPayload -> FCU -> FCU -> GetPaylod  -> NewPayload ...
  |-Payload building 1-| ......................................|-Payload building 2-|


This feature batches the payload building requests. When a new epoch starts, the deposit transactions are added to the payload to be included in the block. Subsequent payload attributes, until the end of the epoch, do not require any additional information from L1. As a result, they can be generated and batched together with the first one, allowing the miner to start the next payload building without waiting for an FCU call.

This approach adds 10% more time (with a 1-second block time) to block building that was previously wasted waiting for the next building signal. The miner can use this extra time to execute more transactions and earn higher rewards. Ultimately, this increases system throughput. More detailed performance numbers will be reported.

With new changes, payload building looks like this:

-> NewPayload ->FCU -> FCU -> GetPaylod -> NewPayload -> FCU  -> FCU -> GetPaylod ->...
|------------Payload building 1 ------------- |.|-------------Payload building 2---------------| 
                                                                          
